### PR TITLE
Replace dead link with archived page link.

### DIFF
--- a/content/posts/the-end-of-indie-web-browsers.md
+++ b/content/posts/the-end-of-indie-web-browsers.md
@@ -77,7 +77,7 @@ And now... we wait. [Possibly for over four months, like I did.](/posts/google-w
 
 Even developers of Brave browser—founded by _the creator of JavaScript_—[faced similar delays in communication](https://github.com/brave/browser-laptop/issues/10449#issuecomment-323800130).
 
-And if we ever do get a license agreement sent to us, according to castLabs (a [Certified Widevine Implementation Partner](https://www.widevine.com/training)), we [also need Google to bless the authenticity of our browser](https://github.com/castlabs/electron-releases#verified-media-path-vmp) before we can ship to production.
+And if we ever do get a license agreement sent to us, according to castLabs (a [Certified Widevine Implementation Partner](https://www.widevine.com/training)), we [also need Google to bless the authenticity of our browser](https://web.archive.org/web/20200110070405/https://github.com/castlabs/electron-releases#verified-media-path-vmp) before we can ship to production.
 
 > Once a license agreement is in place you will be asked to provide CSRs for development and production VMP certificates. Google will sign and return the certificates enabling them to be used for VMP-signing your applications.
 


### PR DESCRIPTION
They removed the entire VMP section from the README.md (catastrophic). The Wayback Machine archive link is 2 days after the publish date of the blog article.

On that note, they left a link to the [this page](https://github.com/castlabs/electron-releases/wiki/VMP) to which they moved the info about VMP. According to the latest info on that page, you no longer need google to bless your software to obtain a VMP certificate; it can now be done quickly and for free through a cli tool, much like certbot. So, Metastream Browser revive??? (((probs unreal)))

On _another_ note:...
> The End of Indie Web Browsers: You Can (Not) Compete

Fun Fact? My first party watch ever using Metastream was Evangelion 1.0: You Are (Not) Alone :)